### PR TITLE
[#149955581] Disable use of `libsolv`

### DIFF
--- a/meta/recipes-devtools/opkg/opkg_0.3.4.bb
+++ b/meta/recipes-devtools/opkg/opkg_0.3.4.bb
@@ -28,7 +28,7 @@ SYSTEMD_SERVICE_${PN} = "opkg-configure.service"
 target_localstatedir := "${localstatedir}"
 OPKGLIBDIR = "${target_localstatedir}/lib"
 
-PACKAGECONFIG ??= "libsolv"
+PACKAGECONFIG ??= ""
 
 PACKAGECONFIG[gpg] = "--enable-gpg,--disable-gpg,gpgme libgpg-error,gnupg"
 PACKAGECONFIG[curl] = "--enable-curl,--disable-curl,curl"


### PR DESCRIPTION
Libsolv is a library used to solve dependencies. Opkg is now set to use this by default, but it renders the use of command `list-upgradable` unusable. Therefore it is disabled for now.