### PR TITLE
[#153211414] Add link to libudev for idreader bridge

### DIFF
--- a/meta/recipes-core/udev/eudev_3.2.bb
+++ b/meta/recipes-core/udev/eudev_3.2.bb
@@ -54,6 +54,8 @@ do_install_append() {
 
 	# hid2hci has moved to bluez4. removed in udev as of version 169
 	rm -f ${D}${base_libdir}/udev/hid2hci
+
+    ln -s libudev.so.1 ${D}/lib/libudev.so.0
 }
 
 INITSCRIPT_PACKAGES = "eudev udev-cache"

--- a/meta/recipes-core/udev/eudev_3.2.bb
+++ b/meta/recipes-core/udev/eudev_3.2.bb
@@ -55,7 +55,7 @@ do_install_append() {
 	# hid2hci has moved to bluez4. removed in udev as of version 169
 	rm -f ${D}${base_libdir}/udev/hid2hci
 
-    ln -s libudev.so.1 ${D}/lib/libudev.so.0
+	ln -s libudev.so.1 ${D}/lib/libudev.so.0
 }
 
 INITSCRIPT_PACKAGES = "eudev udev-cache"


### PR DESCRIPTION
The idreader bridge requires the linux library `libudev.so.0`. This
library is replaced by `libudev.so.1` in openembedded core. The abi
however is compatible, so a simple link makes it work. This link is
created at install time of the eudev recipe.