### PR TITLE
[#153210814] Work around the halting bug

### DIFF
--- a/meta/recipes-core/initscripts/initscripts-1.0/halt
+++ b/meta/recipes-core/initscripts/initscripts-1.0/halt
@@ -24,6 +24,6 @@ then
 	hddown=""
 fi
 
-#halt SED_HALTARGS $hddown
+#halt SED_HALTARGS -p $hddown
 
 : exit 0

--- a/meta/recipes-core/initscripts/initscripts-1.0/halt
+++ b/meta/recipes-core/initscripts/initscripts-1.0/halt
@@ -24,6 +24,6 @@ then
 	hddown=""
 fi
 
-halt SED_HALTARGS -p $hddown
+#halt SED_HALTARGS $hddown
 
 : exit 0

--- a/meta/recipes-core/initscripts/initscripts-1.0/halt
+++ b/meta/recipes-core/initscripts/initscripts-1.0/halt
@@ -24,6 +24,10 @@ then
 	hddown=""
 fi
 
+# This makes the kernel shut down. We decided to take this part out
+# for now, because it causes a watchdog intervention. The filesystem
+# is unmounted at this point, so resetting the unit here should cause
+# no problems. 
 #halt SED_HALTARGS -p $hddown
 
 : exit 0


### PR DESCRIPTION
By not stopping the kernel after a shutdown, the watchdog will not
intervene. However the kernel keeps running, the filesystem is already
unmounted, so there should be no nasty side effects. No state is saved
that could break the system.

Because halting is only used for the USB-cable-factory-reset, which is
only used about 20 times a month, we decided that this workaround is
sufficient for now.