### PR TITLE
[#160410995] Remove `/etc/resolv.conf` from volatiles

### DIFF
--- a/meta/recipes-core/initscripts/initscripts-1.0/volatiles
+++ b/meta/recipes-core/initscripts/initscripts-1.0/volatiles
@@ -34,5 +34,4 @@ l root root 1777 /tmp /var/tmp
 d root root 0755 /var/lock/subsys none
 f root root 0664 /var/log/wtmp none
 f root root 0664 /var/run/utmp none
-l root root 0644 /etc/resolv.conf /var/run/resolv.conf
 f root root 0644 /var/run/resolv.conf none


### PR DESCRIPTION
The volatiles construction helps setting up the files that have to
disappear at reboot. This volatiles construction creates a symbolic
link from `/etc/resolv.conf` to `/var/run/resolv.conf`. `/var/run` is
a `tempfs` meaning that everything in there is in RAM and therefore
volatile, meaning it is gone after a reboot. Overwriting the symbolic
link with a file in previous versions of openembedded did not cause
it to be removed. The current version does however overwrite the file
with a link even if it exists. Rolling back this functionality could
cause all kinds of problems in other places where it is desired that
these files are overwritten, so the most simple way is just not to
create the link at all. This way, there is no `/etc/resolv.conf` upto
the point in the wizard where the WAN interface is chosen. Before the
WAN selection page, no internet connection or DNS resolving is needed
and at this page it is generated by the Renos scripting, thus making
it save to not have this symbolic link at all. During a migration the
file is copied from the old system, so it is available at boot right
away.