### PR TITLE
🐞 [#160509631] Fix revision number on `busybox` recipe

### DIFF
--- a/meta/recipes-core/busybox/busybox.inc
+++ b/meta/recipes-core/busybox/busybox.inc
@@ -4,7 +4,7 @@ HOMEPAGE = "http://www.busybox.net"
 BUGTRACKER = "https://bugs.busybox.net/"
 
 DEPENDS += "kern-tools-native"
-PR = "1"
+PR = "r1"
 
 # bzip2 applet in busybox is based on lightly-modified bzip2 source
 # the GPL is version 2 only


### PR DESCRIPTION
Busybox was not updated correctly because the revision number was set
to `1` instead of the usual `r1`.