### PR TITLE
💉 [#164163496] Fix update-ca-certificates postinstall

### DIFF
--- a/meta/recipes-support/ca-certificates/ca-certificates/0004-update-ca-certificates-use-c-rehash-instead-of-openssl-rehash.patch
+++ b/meta/recipes-support/ca-certificates/ca-certificates/0004-update-ca-certificates-use-c-rehash-instead-of-openssl-rehash.patch
@@ -1,0 +1,77 @@
+diff --git a/debian/changelog b/debian/changelog
+index 3c8eb7f..b0b0eb0 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -45,8 +45,6 @@ ca-certificates (20180409) unstable; urgency=medium
+     Fix lintian file-contains-trailing-whitespace.
+   * debian/{compat,control}:
+     Set to debhelper compat 11.
+-  * Update openssl dependency to >= 1.1.0 to support `openssl rehash` and drop
+-    usage of `c_rehash` script. Closes: #895075
+ 
+   [ Thijs Kinkhorst ]
+   * Remove Christian Perrier from uploaders at his request (closes: #894070).
+diff --git a/debian/control b/debian/control
+index 15fc66b..57cf3e8 100644
+--- a/debian/control
++++ b/debian/control
+@@ -12,7 +12,7 @@ Vcs-Browser: https://salsa.debian.org/debian/ca-certificates
+ 
+ Package: ca-certificates
+ Architecture: all
+-Depends: openssl (>= 1.1.0), ${misc:Depends}
++Depends: openssl (>= 1.0.0), ${misc:Depends}
+ Enhances: openssl
+ Multi-Arch: foreign
+ Breaks: ca-certificates-java (<<20121112+nmu1)
+diff --git a/debian/rules b/debian/rules
+index cf5542d..a935300 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -60,7 +60,7 @@ install: build
+ 	install -d -m 0755 "$(CURDIR)/debian/ca-certificates-udeb/etc/ssl/certs"
+ 	(cd mozilla; \
+ 	 $(MAKE) install CERTSDIR="$(CURDIR)/debian/ca-certificates-udeb/etc/ssl/certs")
+-	openssl rehash -v "$(CURDIR)/debian/ca-certificates-udeb/etc/ssl/certs"
++	c_rehash -v "$(CURDIR)/debian/ca-certificates-udeb/etc/ssl/certs"
+ 
+ # Build architecture-independent files here.
+ binary-indep: build install
+diff --git a/sbin/update-ca-certificates b/sbin/update-ca-certificates
+index 1d6339a..fbfeb73 100755
+--- a/sbin/update-ca-certificates
++++ b/sbin/update-ca-certificates
+@@ -174,9 +174,9 @@ then
+   # only run if set of files has changed
+   if [ "$verbose" = 0 ]
+   then
+-    openssl rehash . > /dev/null
++    c_rehash . > /dev/null
+   else
+-    openssl rehash .
++    c_rehash .
+   fi
+ fi
+ 
+diff --git a/sbin/update-ca-certificates.8 b/sbin/update-ca-certificates.8
+index c60eab1..a76541d 100644
+--- a/sbin/update-ca-certificates.8
++++ b/sbin/update-ca-certificates.8
+@@ -50,7 +50,7 @@ A summary of options is included below.
+ Show summary of options.
+ .TP
+ .B \-v, \-\-verbose
+-Be verbose. Output \fBopenssl rehash\fP.
++Be verbose. Output \fBc_rehash\fP.
+ .TP
+ .B \-f, \-\-fresh
+ Fresh updates.  Remove symlinks in /etc/ssl/certs directory.
+@@ -69,7 +69,7 @@ Directory of CA certificates.
+ .I /usr/local/share/ca-certificates
+ Directory of local CA certificates (with .crt extension).
+ .SH SEE ALSO
+-.BR openssl (1)
++.BR c_rehash (1)
+ .SH AUTHOR
+ This manual page was written by Fumitoshi UKAI <ukai@debian.or.jp>,
+ for the Debian project (but may be used by others).

--- a/meta/recipes-support/ca-certificates/ca-certificates_20180409.bb
+++ b/meta/recipes-support/ca-certificates/ca-certificates_20180409.bb
@@ -7,6 +7,8 @@ SECTION = "misc"
 LICENSE = "GPL-2.0+ & MPL-2.0"
 LIC_FILES_CHKSUM = "file://debian/copyright;md5=aeb420429b1659507e0a5a1b123e8308"
 
+PR = "r1"
+
 # This is needed to ensure we can run the postinst at image creation time
 DEPENDS = ""
 DEPENDS_class-native = "openssl-native"
@@ -17,12 +19,13 @@ PACKAGE_WRITE_DEPS += "openssl-native debianutils-native"
 SRCREV = "dbbd11e56af93bb79f21d0ee6059a901f83f70a5"
 
 SRC_URI = "git://salsa.debian.org/debian/ca-certificates.git;protocol=https \
-           file://0002-update-ca-certificates-use-SYSROOT.patch \
            file://0001-update-ca-certificates-don-t-use-Debianisms-in-run-p.patch \
+           file://0002-update-ca-certificates-use-SYSROOT.patch \
+           file://0003-update-ca-certificates-use-relative-symlinks-from-ET.patch \
+           file://0004-update-ca-certificates-use-c-rehash-instead-of-openssl-rehash.patch \
            file://update-ca-certificates-support-Toybox.patch \
            file://default-sysroot.patch \
            file://sbindir.patch \
-           file://0003-update-ca-certificates-use-relative-symlinks-from-ET.patch \
            "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
The CA-certificates package runs the command `update-ca-certificates`
in the post install script. This command actually is a script itself.
It makes use of the `openssl rehash` command. This command however is
not in the version of openssl we use. We use version 1.0.2j, while it
is introduced in 1.1.0. Updating openssl is not doable for the moment
because we want to release quickly and do not have the time to fit in
openssl 1.1.0+ because it is widely used throughout the yocto project
and poky. We can always choose to update it in the future.